### PR TITLE
Make LonelyTimer depend on the live package instead of the local version

### DIFF
--- a/Examples/LonelyTimer/Package.resolved
+++ b/Examples/LonelyTimer/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "composable-effect-identifier",
+        "repositoryURL": "https://github.com/tgrapperon/composable-effect-identifier",
+        "state": {
+          "branch": null,
+          "revision": "5272092e67a1dc64ffc4d20d17fc15e084bd22d9",
+          "version": "0.0.1"
+        }
+      },
+      {
         "package": "swift-case-paths",
         "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
         "state": {

--- a/Examples/LonelyTimer/Package.swift
+++ b/Examples/LonelyTimer/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
       targets: ["LonelyTimer"])
   ],
   dependencies: [
-    .package(path: "../../"),
     .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "0.33.1"),
+    .package(url: "https://github.com/tgrapperon/composable-effect-identifier", from: "0.0.1"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
The `../../` local dependency is apparently causing issues with Swift Package Index builds.
The local version should still be used by Xcode when using the `ComposableIdentifier` workspace, so I'll make `LonelyTimer` depend on the online version to check if it solves the issue.
Otherwise, I'll need to check if SPI provides an API to build only the top-level package.