### PR TITLE
Revert "Make LonelyTimer depend on the live package"

### DIFF
--- a/Examples/LonelyTimer/Package.resolved
+++ b/Examples/LonelyTimer/Package.resolved
@@ -11,15 +11,6 @@
         }
       },
       {
-        "package": "composable-effect-identifier",
-        "repositoryURL": "https://github.com/tgrapperon/composable-effect-identifier",
-        "state": {
-          "branch": null,
-          "revision": "5272092e67a1dc64ffc4d20d17fc15e084bd22d9",
-          "version": "0.0.1"
-        }
-      },
-      {
         "package": "swift-case-paths",
         "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
         "state": {

--- a/Examples/LonelyTimer/Package.swift
+++ b/Examples/LonelyTimer/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
       targets: ["LonelyTimer"])
   ],
   dependencies: [
+    .package(path: "../../"),
     .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "0.33.1"),
-    .package(url: "https://github.com/tgrapperon/composable-effect-identifier", from: "0.0.1"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
This is not fixing the issue with SPI.

This reverts commit 906a0dda5f8b65d0e7ad79802560134cad1a47e1.