### PR TITLE
Add an explicit name to the local dependency in `LonelyTimer`

### DIFF
--- a/Examples/LonelyTimer/Package.swift
+++ b/Examples/LonelyTimer/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
       targets: ["LonelyTimer"])
   ],
   dependencies: [
-    .package(path: "../../"),
+    .package(name: "composable-effect-identifier", path: "../../"),
     .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "0.33.1"),
   ],
   targets: [


### PR DESCRIPTION
This should fix issues with sample code when the user clones the repository in some arbitrary named folder.